### PR TITLE
Introduce support for WireMock extensions

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -16,9 +16,7 @@ on:
 
 jobs:
   build:
-
     runs-on: ubuntu-latest
-
     steps:
     - uses: actions/checkout@v3
     - name: Set up JDK 11
@@ -29,7 +27,3 @@ jobs:
         cache: maven
     - name: Build with Maven
       run: mvn -B package --file pom.xml
-
-    # Optional: Uploads the full dependency graph to GitHub to improve the quality of Dependabot alerts this repository can receive
-    - name: Update dependency graph
-      uses: advanced-security/maven-dependency-submission-action@571e99aab1055c2e71a1e2309b9691de18d6b7d6

--- a/README.md
+++ b/README.md
@@ -50,10 +50,8 @@ public class WireMockContainerTest {
 
     @Test
     public void helloWorld() throws Exception {
-        final HttpClient client = HttpClient.newBuilder()
-                .version(HttpClient.Version.HTTP_1_1).build();
-
-        HttpRequest request = HttpRequest.newBuilder()
+        final HttpClient client = HttpClient.newBuilder().build();
+        final HttpRequest request = HttpRequest.newBuilder()
                 .uri(wiremockServer.getRequestURI("hello"))
                 .timeout(Duration.ofSeconds(10))
                 .header("Content-Type", "application/json")
@@ -69,16 +67,101 @@ public class WireMockContainerTest {
 }
 ```
 
-### Using extensions
+### Using WireMock extensions
 
 The API supports adding [WireMock extensions](https://wiremock.org/docs/extending-wiremock/)
 to the test container.
 The extension can be sourced from the classpath for bundled extensions,
 or added from the JAR file in the initializer.
 
-#### Using external extension
+#### Using external extensions
 
-For the , an extension Jar should be 
+For the external extensions,
+an extension Jar should be pulled to the test directory before running the test.
+[Apache Maven Dependency Plugin](https://maven.apache.org/plugins/maven-dependency-plugin/) can be used for this purpose.
+Make sure that all dependencies of the extension JAR, if any,
+are also included.
+
+Below you can see an examples of using the _JSON Body Transformer_ extension
+from the [9cookies/wiremock-extensions](https://github.com/9cookies/wiremock-extensions).
+
+Copying the dependency:
+
+```xml
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-dependency-plugin</artifactId>
+        <version>3.5.0</version>
+        <executions>
+          <execution>
+            <id>copy</id>
+            <phase>package</phase>
+            <goals>
+              <goal>copy</goal>
+            </goals>
+            <configuration>
+              <artifactItems>
+                <artifactItem>
+                  <groupId>com.ninecookies.wiremock.extensions</groupId>
+                  <artifactId>wiremock-extensions</artifactId>
+                  <version>0.4.1</version>
+                  <classifier>jar-with-dependencies</classifier>
+                </artifactItem>
+              </artifactItems>
+              <outputDirectory>${project.build.directory}/test-wiremock-extension</outputDirectory>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
+```
+
+Mapping definition:
+
+```json
+{
+  "request": {
+    "method": "POST",
+    "url": "/json-body-transformer"
+  },
+  "response": {
+    "status": 201,
+    "headers": {
+      "content-type": "application/json"
+    },
+    "jsonBody": {
+      "message": "Hello, $(name)!"
+    },
+    "transformers" : ["json-body-transformer"]
+  }
+}
+```
+
+Test sample:
+
+```java
+public class WireMockContainerExtensionTest {
+    @Rule
+    public WireMockContainer wiremockServer = new WireMockContainer("2.35.0")
+            .withMapping("json-body-transformer", WireMockContainerExtensionTest.class, "json-body-transformer.json")
+            .withExtension("JSON Body Transformer", Collections.singleton("com.ninecookies.wiremock.extensions.JsonBodyTransformer"),
+                    Collections.singleton(Paths.get("target", "test-wiremock-extension", "9cookies-wiremock-extensions.jar").toFile()));
+
+    @Test
+    public void testJSONBodyTransformer() throws Exception {
+        final HttpClient client = HttpClient.newBuilder().build();
+        final HttpRequest request = HttpRequest.newBuilder()
+                .uri(wiremockServer.getRequestURI("json-body-transformer"))
+                .timeout(Duration.ofSeconds(10))
+                .header("Content-Type", "application/json")
+                .POST(HttpRequest.BodyPublishers.ofString("{\"name\":\"John Doe\"}")).build();
+
+        HttpResponse<String> response = client.send(request, HttpResponse.BodyHandlers.ofString());
+
+        assertThat(response.body()).as("Wrong response body")
+                .contains("Hello, John Doe!");
+    }
+}
+```
 
 ## Contributing
 

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ A common example is using Wiremock 3.x with Java 1.8.
 
 ## Usage
 
-Import the dependency:
+### Importing the dependency
 
 ```xml
     <dependency>
@@ -28,8 +28,9 @@ Import the dependency:
     </dependency>
 ```
 
-Use it in your Unit tests.
-Javadoc is coming soon!
+### Using the test container in JUnit 4/5
+
+P.S: Javadoc is coming soon!
 
 ```java
 import org.wiremock.integrations.testcontainers.WireMockContainer;
@@ -67,6 +68,17 @@ public class WireMockContainerTest {
     }
 }
 ```
+
+### Using extensions
+
+The API supports adding [WireMock extensions](https://wiremock.org/docs/extending-wiremock/)
+to the test container.
+The extension can be sourced from the classpath for bundled extensions,
+or added from the JAR file in the initializer.
+
+#### Using external extension
+
+For the , an extension Jar should be 
 
 ## Contributing
 

--- a/pom.xml
+++ b/pom.xml
@@ -123,13 +123,9 @@
                   <artifactId>wiremock-extensions</artifactId>
                   <version>0.4.1</version>
                   <classifier>jar-with-dependencies</classifier>
-                  <overWrite>false</overWrite>
-                  <destFileName>9cookies-wiremock-extensions.jar</destFileName>
                 </artifactItem>
               </artifactItems>
               <outputDirectory>${project.build.directory}/test-wiremock-extension</outputDirectory>
-              <overWriteReleases>false</overWriteReleases>
-              <overWriteSnapshots>true</overWriteSnapshots>
             </configuration>
           </execution>
         </executions>

--- a/pom.xml
+++ b/pom.xml
@@ -127,6 +127,7 @@
                   <destFileName>9cookies-wiremock-extensions.jar</destFileName>
                 </artifactItem>
               </artifactItems>
+              <!--<includeScope>runtime</includeScope>-->
               <excludeArtifactIds>testcontainers</excludeArtifactIds> <!--Looks like the library defect, it should be provided-->
               <outputDirectory>${project.build.directory}/test-wiremock-extension</outputDirectory>
               <overWriteReleases>false</overWriteReleases>

--- a/pom.xml
+++ b/pom.xml
@@ -115,7 +115,6 @@
             <phase>package</phase>
             <goals>
               <goal>copy</goal>
-              <goal>copy-dependencies</goal>
             </goals>
             <configuration>
               <artifactItems>
@@ -123,12 +122,11 @@
                   <groupId>com.ninecookies.wiremock.extensions</groupId>
                   <artifactId>wiremock-extensions</artifactId>
                   <version>0.4.1</version>
+                  <classifier>jar-with-dependencies</classifier>
                   <overWrite>false</overWrite>
                   <destFileName>9cookies-wiremock-extensions.jar</destFileName>
                 </artifactItem>
               </artifactItems>
-              <!--<includeScope>runtime</includeScope>-->
-              <excludeArtifactIds>testcontainers</excludeArtifactIds> <!--Looks like the library defect, it should be provided-->
               <outputDirectory>${project.build.directory}/test-wiremock-extension</outputDirectory>
               <overWriteReleases>false</overWriteReleases>
               <overWriteSnapshots>true</overWriteSnapshots>

--- a/pom.xml
+++ b/pom.xml
@@ -103,7 +103,50 @@
           </execution>
         </executions>
       </plugin>
+
+      <!-- For testing WireMock extensions -->
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-dependency-plugin</artifactId>
+        <version>3.5.0</version>
+        <executions>
+          <execution>
+            <id>copy</id>
+            <phase>package</phase>
+            <goals>
+              <goal>copy</goal>
+              <goal>copy-dependencies</goal>
+            </goals>
+            <configuration>
+              <artifactItems>
+                <artifactItem>
+                  <groupId>com.ninecookies.wiremock.extensions</groupId>
+                  <artifactId>wiremock-extensions</artifactId>
+                  <version>0.4.1</version>
+                  <overWrite>false</overWrite>
+                  <destFileName>9cookies-wiremock-extensions.jar</destFileName>
+                </artifactItem>
+              </artifactItems>
+              <excludeArtifactIds>testcontainers</excludeArtifactIds> <!--Looks like the library defect, it should be provided-->
+              <outputDirectory>${project.build.directory}/test-wiremock-extension</outputDirectory>
+              <overWriteReleases>false</overWriteReleases>
+              <overWriteSnapshots>true</overWriteSnapshots>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
     </plugins>
   </build>
 
+  <!-- For testing WireMock extensions -->
+  <repositories>
+    <repository>
+      <id>9c-releases</id>
+      <url>https://raw.github.com/9cookies/mvn-repo/master/releases/</url>
+      <releases>
+        <enabled>true</enabled>
+        <updatePolicy>always</updatePolicy>
+      </releases>
+    </repository>
+  </repositories>
 </project>

--- a/src/main/java/org/wiremock/integrations/testcontainers/WireMockContainer.java
+++ b/src/main/java/org/wiremock/integrations/testcontainers/WireMockContainer.java
@@ -21,8 +21,16 @@ import java.net.URI;
 import java.net.URISyntaxException;
 import java.net.URL;
 import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 import org.testcontainers.containers.GenericContainer;
 import org.testcontainers.images.builder.Transferable;
@@ -31,6 +39,8 @@ import org.testcontainers.utility.MountableFile;
 
 /**
  * Provisions WireMock standalone server as a container.
+ * Designed to follow the WireMock Docker image ({@code wiremock/wiremock}) structure and configuration,
+ * but other images can be included too at your own risk.
  */
 public class WireMockContainer extends GenericContainer<WireMockContainer> {
     private static final String DEFAULT_IMAGE_NAME = "wiremock/wiremock";
@@ -39,12 +49,15 @@ public class WireMockContainer extends GenericContainer<WireMockContainer> {
     private static final String MAPPINGS_DIR = "/home/wiremock/mappings/";
     private static final String FILES_DIR = "/home/wiremock/__files/";
 
+    private static final String EXTENSIONS_DIR = "/var/wiremock/extensions/";
+
     private static final int PORT = 8080;
 
     private final StringBuilder wireMockArgs;
 
     private final Map<String, Stub> mappingStubs = new HashMap<>();
     private final Map<String, MountableFile> mappingFiles = new HashMap<>();
+    private final Map<String, Extension> extensions = new HashMap<>();
 
     public WireMockContainer() {
         this(DEFAULT_TAG);
@@ -115,6 +128,55 @@ public class WireMockContainer extends GenericContainer<WireMockContainer> {
         return withFileFromResource(name, resource.getName().replace('.', '/') + "/" + filename);
     }
 
+    /**
+     * Add extension that will be loaded from the specified JAR file.
+     * @param id Unique ID of the extension, for logging purposes
+     * @param classNames Class names of the extension to be included
+     * @param jars JARs to be included into the container
+     * @return this instance
+     */
+    public WireMockContainer withExtension(String id, Collection<String> classNames, Collection<File> jars) {
+        final Extension extension = new Extension(id);
+        extension.extensionClassNames.addAll(classNames);
+        extension.jars.addAll(jars);
+        extensions.put(id, extension);
+        return this;
+    }
+
+    /**
+     * Add extension that will be loaded from the specified directory with JAR files.
+     * @param id Unique ID of the extension, for logging purposes
+     * @param classNames Class names of the extension to be included
+     * @param jarDirectory Directory that stores all JARs
+     * @return this instance
+     */
+    public WireMockContainer withExtension(String id, Collection<String> classNames, File jarDirectory) {
+        final List<File> jarsInTheDirectory;
+        try (Stream<Path> walk = Files.walk(jarDirectory.toPath())) {
+            jarsInTheDirectory = walk
+                    .filter(p -> !Files.isDirectory(p))
+                    .map(Path::toFile)
+                    .filter(f -> f.toString().endsWith(".jar"))
+                    .collect(Collectors.toList());
+        } catch (IOException e) {
+            throw new IllegalArgumentException("Cannot list JARs in the directory " + jarDirectory, e);
+        }
+
+        return withExtension(id, classNames, jarsInTheDirectory);
+    }
+
+    /**
+     * Add extension that will be loaded from the classpath.
+     * This method can be used if the extension is a part of the WireMock bundle,
+     * or a Jar is already added via {@link #withExtension(String, Collection, Collection)}}
+     * @param id Unique ID of the extension, for logging purposes
+     * @param className Class name of the extension
+     * @return this instance
+     */
+    public WireMockContainer withExtension(String id, String className) {
+        return withExtension(id, Collections.singleton(className), Collections.emptyList());
+    }
+
     public String getEndpoint() {
         return String.format("http://%s:%d", getHost(), getMappedPort(PORT));
     }
@@ -131,7 +193,6 @@ public class WireMockContainer extends GenericContainer<WireMockContainer> {
     protected void configure() {
         super.configure();
         withExposedPorts(PORT);
-        withCommand(wireMockArgs.toString());
         for (Stub stub : mappingStubs.values()) {
             withCopyToContainer(Transferable.of(stub.json), MAPPINGS_DIR + stub.name + ".json");
         }
@@ -139,6 +200,26 @@ public class WireMockContainer extends GenericContainer<WireMockContainer> {
         for (Map.Entry<String, MountableFile> mount : mappingFiles.entrySet()) {
             withCopyToContainer(mount.getValue(), FILES_DIR + mount.getKey());
         }
+
+        final ArrayList<String> extensionClassNames = new ArrayList<>();
+        for (Map.Entry<String, Extension> entry : extensions.entrySet()) {
+            final Extension ext = entry.getValue();
+            extensionClassNames.addAll(ext.extensionClassNames);
+            for (File jar : ext.jars) {
+                withCopyToContainer(MountableFile.forHostPath(jar.toPath()), EXTENSIONS_DIR + jar.getName());
+            }
+        }
+        if (!extensionClassNames.isEmpty()) {
+            wireMockArgs.append(" --extensions ");
+            int counter = 0;
+            for (String className : extensionClassNames) {
+                wireMockArgs.append(className);
+                wireMockArgs.append( (++counter != extensionClassNames.size()) ? ',' : ' ');
+            }
+        }
+
+        // Add CLI arguments
+        withCommand(wireMockArgs.toString());
     }
 
     private static final class Stub {
@@ -148,6 +229,16 @@ public class WireMockContainer extends GenericContainer<WireMockContainer> {
         public Stub (String name, String json) {
             this.name = name;
             this.json = json;
+        }
+    }
+
+    private static final class Extension {
+        final String id;
+        final List<File> jars = new ArrayList<>();
+        final List<String> extensionClassNames = new ArrayList<>();
+
+        public Extension(String id) {
+            this.id = id;
         }
     }
 

--- a/src/test/java/org/wiremock/integrations/testcontainers/WireMockContainerExtensionTest.java
+++ b/src/test/java/org/wiremock/integrations/testcontainers/WireMockContainerExtensionTest.java
@@ -39,9 +39,8 @@ public class WireMockContainerExtensionTest {
 
     public static final Logger LOGGER =  LoggerFactory.getLogger(WireMockContainerExtensionTest.class);
 
-    //TODO: The extension won't work righe with newer WireMock versions because of relocations
     @Rule
-    public WireMockContainer wiremockServer = new WireMockContainer("2.26.0")
+    public WireMockContainer wiremockServer = new WireMockContainer("2.35.0")
             .withStartupTimeout(Duration.ofSeconds(60))
             .withMapping("json-body-transformer", WireMockContainerExtensionTest.class, "json-body-transformer.json")
             .withExtension("JSON Body Transformer", Collections.singleton("com.ninecookies.wiremock.extensions.JsonBodyTransformer"),

--- a/src/test/java/org/wiremock/integrations/testcontainers/WireMockContainerExtensionTest.java
+++ b/src/test/java/org/wiremock/integrations/testcontainers/WireMockContainerExtensionTest.java
@@ -39,8 +39,9 @@ public class WireMockContainerExtensionTest {
 
     public static final Logger LOGGER =  LoggerFactory.getLogger(WireMockContainerExtensionTest.class);
 
+    //TODO: The extension won't work righe with newer WireMock versions because of relocations
     @Rule
-    public WireMockContainer wiremockServer = new WireMockContainer("2.35.0")
+    public WireMockContainer wiremockServer = new WireMockContainer("2.26.0")
             .withStartupTimeout(Duration.ofSeconds(60))
             .withMapping("json-body-transformer", WireMockContainerExtensionTest.class, "json-body-transformer.json")
             .withExtension("JSON Body Transformer", Collections.singleton("com.ninecookies.wiremock.extensions.JsonBodyTransformer"),

--- a/src/test/resources/org/wiremock/integrations/testcontainers/WireMockContainerExtensionTest/json-body-transformer.json
+++ b/src/test/resources/org/wiremock/integrations/testcontainers/WireMockContainerExtensionTest/json-body-transformer.json
@@ -1,0 +1,16 @@
+{
+  "request": {
+    "method": "POST",
+    "url": "/json-body-transformer"
+  },
+  "response": {
+    "status": 201,
+    "headers": {
+      "content-type": "application/json"
+    },
+    "jsonBody": {
+      "message": "Hello, $(name)!"
+    },
+    "transformers" : ["json-body-transformer"]
+  }
+}


### PR DESCRIPTION
Adds support for using extensions

- [x] Create working skeleton
- [x] Fix issues with startup of the test container (works on my machine with the same args)
- [x] Fix classloading for the extension handler
- [x] Finish documentation